### PR TITLE
Expose save details and trim scenes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -165,7 +165,7 @@ const App: React.FC = () => {
       const { chat, scene } = await llm.startAdventure(config, startPrompt);
       console.log("llm.startAdventure returned:", { chat, scene });
       console.log("Calling image.generateSceneImage...");
-      const imageResult = await image.generateSceneImage(scene.description, scene.theme);
+      const imageResult = await image.generateSceneImage(scene.imagePrompt || scene.description, scene.theme);
       console.log("image.generateSceneImage returned:", imageResult);
       
       const newGameState: GameState = {
@@ -256,7 +256,11 @@ const App: React.FC = () => {
       );
       console.log("continueAdventure returned:", scene);
 
-      const image = await imageProvider.generateSceneImage(scene.description, scene.theme);
+      const image = await imageProvider.generateSceneImage(
+        scene.imagePrompt || scene.description,
+        scene.theme,
+        gameState.currentScene.imagePrompt || gameState.currentScene.description
+      );
       console.log("generateSceneImage returned:", image);
 
       const previousEntry: HistoryEntry = {

--- a/components/LLMProviderSelector.tsx
+++ b/components/LLMProviderSelector.tsx
@@ -82,17 +82,32 @@ const LLMProviderSelector: React.FC<LLMProviderSelectorProps> = ({
       </div>
 
       {selectedLLMConfig.provider === 'Gemini' && (
-        <div>
-          <label htmlFor="gemini-api-key" className="block text-sm font-medium text-[var(--color-text-muted)] mb-2">Gemini API Key</label>
-          <input
-            type="password"
-            id="gemini-api-key"
-            value={selectedLLMConfig.apiKey || ''}
-            onChange={handleApiKeyChange}
-            className="bg-[var(--color-surface)] border-2 border-[var(--color-primary)] text-[var(--color-text)] text-base font-semibold rounded-lg shadow-md focus:ring-[var(--color-accent)] focus:border-[var(--color-accent)] block w-full pl-4 pr-10 py-3 transition-colors duration-300"
-            placeholder="Enter your Gemini API Key"
-          />
-        </div>
+        <>
+          <div>
+            <label htmlFor="gemini-api-key" className="block text-sm font-medium text-[var(--color-text-muted)] mb-2">Gemini API Key</label>
+            <input
+              type="password"
+              id="gemini-api-key"
+              value={selectedLLMConfig.apiKey || ''}
+              onChange={handleApiKeyChange}
+              className="bg-[var(--color-surface)] border-2 border-[var(--color-primary)] text-[var(--color-text)] text-base font-semibold rounded-lg shadow-md focus:ring-[var(--color-accent)] focus:border-[var(--color-accent)] block w-full pl-4 pr-10 py-3 transition-colors duration-300"
+              placeholder="Enter your Gemini API Key"
+            />
+          </div>
+          <div>
+            <label htmlFor="gemini-model-select" className="block text-sm font-medium text-[var(--color-text-muted)] mb-2">Model</label>
+            <select
+              id="gemini-model-select"
+              value={selectedLLMConfig.model || ''}
+              onChange={handleModelChange}
+              className="appearance-none bg-[var(--color-surface)] border-2 border-[var(--color-primary)] text-[var(--color-text)] text-base font-semibold rounded-lg shadow-md focus:ring-[var(--color-accent)] focus:border-[var(--color-accent)] block w-full pl-4 pr-10 py-3 transition-colors duration-300"
+            >
+              {availableModels.map(model => (
+                <option key={model} value={model}>{model}</option>
+              ))}
+            </select>
+          </div>
+        </>
       )}
 
       {(selectedLLMConfig.provider === 'LM Studio' || selectedLLMConfig.provider === 'Ollama') && (

--- a/components/NotesViewerModal.tsx
+++ b/components/NotesViewerModal.tsx
@@ -44,6 +44,36 @@ const NotesViewerModal: React.FC<NotesViewerModalProps> = ({ isOpen, onClose, sa
                     )}
                 </div>
             </div>
+            <div>
+                <h3 className="font-semibold text-xl text-[var(--color-primary)] mb-2">Characters</h3>
+                <div className="bg-[var(--color-surface)] p-4 rounded-md">
+                    {saveData.npcs.length > 0 ? (
+                        <ul className="space-y-2 text-[var(--color-text)]">
+                            {saveData.npcs.map(npc => (
+                                <li key={npc.id}>
+                                    <strong className="font-medium">{npc.name}</strong> - {npc.description} (<em>{npc.status}</em>)
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="text-[var(--color-text-muted)]">You have not met any characters yet.</p>
+                    )}
+                </div>
+            </div>
+            <div>
+                <h3 className="font-semibold text-xl text-[var(--color-primary)] mb-2">History</h3>
+                <div className="bg-[var(--color-surface)] p-4 rounded-md">
+                    {saveData.history.length > 0 ? (
+                        <ul className="list-decimal list-inside space-y-1 text-[var(--color-text)]">
+                            {saveData.history.map((h, idx) => (
+                                <li key={idx}>{h.description.slice(0, 80)}...</li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="text-[var(--color-text-muted)]">No prior scenes recorded.</p>
+                    )}
+                </div>
+            </div>
         </div>
         <div className="p-4 border-t border-[var(--color-primary)]/20 text-right">
             <button onClick={onClose} className="bg-[var(--color-surface-accent)] text-[var(--color-text)] font-semibold py-2 px-4 rounded-lg hover:bg-[var(--color-primary)] transition-colors">

--- a/services/llmProviders.ts
+++ b/services/llmProviders.ts
@@ -33,6 +33,7 @@ You will generate a JSON object representing the current scene. This object must
 - "title": A short, evocative title for the scene.
 - "description": A detailed, multi-paragraph description of the environment, atmosphere, and any characters present. Use vivid language to engage the player's senses.
 - "choices": An array of 3-5 distinct actions the player can take. Each choice should be a string.
+- "imagePrompt": One short sentence describing exactly what the player sees from their point of view. Mention notable objects or characters in front of them. This will be used for image generation.
 - "theme": A single keyword suggesting a visual theme for the scene (e.g., "DARK_FOREST", "CYBERPUNK_CITY", "ANCIENT_RUINS").
 
 You must also manage the game's state:
@@ -45,11 +46,12 @@ Key rules:
 1.  Always respond with a valid JSON object matching the specified schema. Do not include any text outside of the JSON structure.
 2.  Ensure the story is coherent and evolves based on player actions.
 3.  Be creative and surprising. Introduce new characters, items, and plot twists.
-4.  The "description" should be at least two paragraphs long.
-5.  The "choices" should be meaningful and lead to different outcomes.
-6.  Update "worldState" and "npcs" logically based on the player's actions.
-7.  If the player's action is nonsensical or impossible, create a response that reflects that in a creative way.
-8.  The "theme" should be chosen from a consistent set of themes to allow for visual theming of the game.
+4.  Keep the "description" brief—no more than two short paragraphs totalling a few sentences.
+5.  Write the description from the second-person perspective, focusing on what the player sees.
+6.  The "choices" should be meaningful and lead to different outcomes.
+7.  Update "worldState" and "npcs" logically based on the player's actions.
+8.  If the player's action is nonsensical or impossible, create a response that reflects that in a creative way.
+9.  The "theme" should be chosen from a consistent set of themes to allow for visual theming of the game.
 `;
 
 const responseSchema = {
@@ -57,6 +59,7 @@ const responseSchema = {
   properties: {
     title: { type: "string" },
     description: { type: "string" },
+    imagePrompt: { type: "string" },
     choices: {
       type: "array",
       items: { type: "string" },
@@ -84,7 +87,7 @@ const responseSchema = {
       },
     },
   },
-  required: ["title", "description", "choices", "theme", "worldState", "npcs"],
+  required: ["title", "description", "imagePrompt", "choices", "theme", "worldState", "npcs"],
 };
 
 


### PR DESCRIPTION
## Summary
- shorten Gemini instructions to keep descriptions brief
- emphasize single-sentence `imagePrompt`
- show inventory, world state, characters and history in NotesViewerModal

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6876d652d5dc83299493443b72fc7508