### PR TITLE
Fix: Correct API key access for image generation

### DIFF
--- a/services/imageProviders.ts
+++ b/services/imageProviders.ts
@@ -31,7 +31,7 @@ export const ImagenProvider: ImageProvider = {
   name: 'Imagen',
   async generateSceneImage(prompt, theme, previousPrompt, location, action) {
     try {
-      const ai = new GoogleGenAI({ apiKey: (typeof process !== 'undefined' ? process.env.API_KEY : undefined) });
+      const ai = new GoogleGenAI({ apiKey: import.meta.env.VITE_GEMINI_API_KEY });
       const style = themeStyles[theme] || themeStyles.FANTASY;
       const continuityPrompt = previousPrompt ? `Continuing from a scene described as '${previousPrompt}', the view now shows:` : '';
       const locationPrompt = location ? `The scene takes place in ${location}.` : '';

--- a/services/imagenService.ts
+++ b/services/imagenService.ts
@@ -1,7 +1,7 @@
 import { GoogleGenAI } from "@google/genai";
 import type { ThemeName } from '../types';
 
-const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+const ai = new GoogleGenAI({ apiKey: import.meta.env.VITE_GEMINI_API_KEY });
 
 const themeStyles: Record<ThemeName, string> = {
     FANTASY: 'dark fantasy art, epic, cinematic lighting, hyperdetailed, intricately detailed',


### PR DESCRIPTION
This commit fixes the image generation issue by correcting the way the API key is accessed in the application. The code was previously using `process.env.API_KEY`, which is not the correct way to access environment variables in a Vite project. This has been replaced with `import.meta.env.VITE_GEMINI_API_KEY` to ensure that the image generation service and provider can authenticate with the Google GenAI API correctly.